### PR TITLE
Expose public run route for HTTP server for local testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @agentuity/sdk
 
+## 0.0.77
+
+### Patch Changes
+
+- Expose public run route for HTTP server for local testing
+
 ## 0.0.76
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentuity/sdk",
-	"version": "0.0.76",
+	"version": "0.0.77",
 	"description": "The Agentuity SDK for NodeJS and Bun",
 	"license": "Apache-2.0",
 	"public": true,


### PR DESCRIPTION
Expose a consistent public route that matches the public API.

You can now run your dev server and use this API:

```
curl -v http://localhost:3500/run/agent_ByN4h67c9ff349JFNKomKhIgsXYcYVy5 --json '{"hi":"bye"}'
```

and you get a response:

```
< HTTP/1.1 200 OK
< Content-Type: application/json
< Date: Fri, 07 Mar 2025 03:15:27 GMT
< Server: Agentuity BunJS/0.0.76
< Date: Fri, 07 Mar 2025 03:15:27 GMT
< Content-Length: 78
<

{"trigger":"manual","payload":"Hi from Agentuity!","contentType":"text/plain"}
```