### PR TITLE
Streaming Support including SSE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # @agentuity/sdk
 
+## 0.0.85
+
+### Patch Changes
+
+- Streaming Support including SSE
+
 ## 0.0.84 - 2025-03-14
 
 ### Added
+
 - Stream IO Input: add new facility to support stream io for input data [#23](https://github.com/agentuity/sdk-js/pull/23)
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentuity/sdk",
-	"version": "0.0.84",
+	"version": "0.0.85",
 	"description": "The Agentuity SDK for NodeJS and Bun",
 	"license": "Apache-2.0",
 	"public": true,

--- a/src/router/response.ts
+++ b/src/router/response.ts
@@ -7,6 +7,7 @@ import type {
 	JsonObject,
 	DataType,
 	AgentRedirectResponse,
+	ReadableDataType,
 } from '../types';
 import type { ReadableStream } from 'node:stream/web';
 import { DataHandler } from './data';
@@ -179,7 +180,7 @@ export default class AgentResponseHandler implements AgentResponse {
 	 * stream a response to the client
 	 */
 	async stream(
-		stream: ReadableStream<Uint8Array> | AsyncIterable<Uint8Array>,
+		stream: ReadableStream<ReadableDataType> | AsyncIterable<ReadableDataType>,
 		contentType: string,
 		metadata?: JsonObject
 	): Promise<AgentResponseData> {

--- a/src/router/response.ts
+++ b/src/router/response.ts
@@ -181,17 +181,15 @@ export default class AgentResponseHandler implements AgentResponse {
 	 */
 	async stream(
 		stream: ReadableStream<ReadableDataType> | AsyncIterable<ReadableDataType>,
-		contentType: string,
-		metadata?: JsonObject
+		contentType?: string
 	): Promise<AgentResponseData> {
 		return {
 			data: new DataHandler(
 				{
-					contentType,
+					contentType: contentType ?? 'text/plain',
 				},
 				stream
 			),
-			metadata,
 		};
 	}
 }

--- a/src/router/response.ts
+++ b/src/router/response.ts
@@ -8,6 +8,7 @@ import type {
 	DataType,
 	AgentRedirectResponse,
 } from '../types';
+import type { ReadableStream } from 'node:stream/web';
 import { DataHandler } from './data';
 import { safeStringify, fromDataType } from '../server/util';
 
@@ -172,5 +173,24 @@ export default class AgentResponseHandler implements AgentResponse {
 	 */
 	ogg(data: DataType, metadata?: JsonObject): Promise<AgentResponseData> {
 		return fromDataType(data, 'audio/ogg', metadata);
+	}
+
+	/**
+	 * stream a response to the client
+	 */
+	async stream(
+		stream: ReadableStream<Uint8Array> | AsyncIterable<Uint8Array>,
+		contentType: string,
+		metadata?: JsonObject
+	): Promise<AgentResponseData> {
+		return {
+			data: new DataHandler(
+				{
+					contentType,
+				},
+				stream
+			),
+			metadata,
+		};
 	}
 }

--- a/src/server/agents.ts
+++ b/src/server/agents.ts
@@ -311,7 +311,7 @@ export default class AgentResolver {
 				if ('name' in params) {
 					span.setStatus({
 						code: SpanStatusCode.ERROR,
-						message: `agent ${params.id} not found or you don't have access to it`,
+						message: `agent ${params.name} not found or you don't have access to it`,
 					});
 					throw new Error(
 						`agent ${params.name} not found or you don't have access to it`

--- a/src/server/node.ts
+++ b/src/server/node.ts
@@ -266,6 +266,8 @@ export class NodeServer implements Server {
 									routeResult
 								);
 								res.writeHead(200, headers);
+								// Ensure headers are sent before streaming
+								res.flushHeaders();
 								// Pipe the stream to the response
 								const reader = stream.getReader();
 								while (true) {

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -16,6 +16,7 @@ export interface ServerRequest {
 	request: IncomingRequest;
 	headers: Record<string, string>;
 	setTimeout: (val: number) => void;
+	controller?: ReadableStreamDefaultController;
 }
 
 /**

--- a/src/server/util.ts
+++ b/src/server/util.ts
@@ -338,7 +338,7 @@ export function createStreamingResponse(
 							const data = await toBuffer(value);
 							if (streamAsSSE) {
 								const buf = Buffer.from(
-									`data: ${data.toString(encoding as BufferEncoding)}\n`,
+									`data: ${data.toString(encoding as BufferEncoding)}\n\n`,
 									'utf-8'
 								);
 								controller.enqueue(buf);

--- a/src/types.ts
+++ b/src/types.ts
@@ -565,7 +565,7 @@ export interface AgentResponse {
 	 * stream a response to the client
 	 */
 	stream(
-		stream: ReadableStream,
+		stream: ReadableStream<ReadableDataType> | AsyncIterable<ReadableDataType>,
 		contentType: string,
 		metadata?: JsonObject
 	): Promise<AgentResponseData>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import type { Tracer } from '@opentelemetry/api';
 import type { Logger } from './logger';
+import type { ReadableStream } from 'node:stream/web';
 
 /**
  * Types of triggers that can initiate an agent request
@@ -56,7 +57,19 @@ export interface Data {
 	 * the binary data represented as a Buffer
 	 */
 	buffer: Buffer;
+
+	/**
+	 * the stream of the data
+	 */
+	stream: ReadableStream<ReadableDataType>;
 }
+
+export type ReadableDataType =
+	| Buffer
+	| Uint8Array
+	| ArrayBuffer
+	| string
+	| Blob;
 
 /**
  * The type of data that can be passed to an agent as a payload
@@ -547,6 +560,15 @@ export interface AgentResponse {
 	 * return an OGG response with optional metadata
 	 */
 	ogg(data: DataType, metadata?: JsonObject): Promise<AgentResponseData>;
+
+	/**
+	 * stream a response to the client
+	 */
+	stream(
+		stream: ReadableStream,
+		contentType: string,
+		metadata?: JsonObject
+	): Promise<AgentResponseData>;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -562,12 +562,11 @@ export interface AgentResponse {
 	ogg(data: DataType, metadata?: JsonObject): Promise<AgentResponseData>;
 
 	/**
-	 * stream a response to the client
+	 * stream a response to the client. the content type will default to text/plain if not provided or if SSE is requested.
 	 */
 	stream(
 		stream: ReadableStream<ReadableDataType> | AsyncIterable<ReadableDataType>,
-		contentType: string,
-		metadata?: JsonObject
+		contentType?: string
 	): Promise<AgentResponseData>;
 }
 


### PR DESCRIPTION
This PR adds initial support for stream both as a response (in general) as well as supporting SSE.

```typescript
import type { AgentRequest, AgentResponse, AgentContext } from "@agentuity/sdk";
import { streamText } from "ai";
import { openai } from "@ai-sdk/openai";

export default async function Agent(
	req: AgentRequest,
	resp: AgentResponse,
	ctx: AgentContext,
) {
	const { textStream } = streamText({
		model: openai("gpt-4o"),
		prompt: "Invent a new holiday and describe its traditions.",
	});

	return resp.stream(textStream);
}
```

If you include Accept: text/event-stream when running the agent, the data will stream using the SSE protocol.

If you don't include this header, it will stream the response in the normal format.