### PR TITLE
Add agentId to context.logger and fix issue with underrun buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @agentuity/sdk
 
+## 0.0.86
+
+### Patch Changes
+
+- Add support for agentId on context.logger
+  Fix issue with underrun on base64 stream
+
 ## 0.0.85
 
 ### Patch Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@agentuity/sdk",
-	"version": "0.0.84",
+	"version": "0.0.86",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@agentuity/sdk",
-			"version": "0.0.84",
+			"version": "0.0.86",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/api": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentuity/sdk",
-	"version": "0.0.85",
+	"version": "0.0.86",
 	"description": "The Agentuity SDK for NodeJS and Bun",
 	"license": "Apache-2.0",
 	"public": true,

--- a/src/otel/logger.ts
+++ b/src/otel/logger.ts
@@ -104,7 +104,7 @@ class OtelLogger implements Logger {
 	child(opts: Record<string, Json>) {
 		return new OtelLogger(!!this.logger, this.delegate, {
 			...(this.context ?? {}),
-			opts,
+			...opts,
 		});
 	}
 }

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -201,6 +201,9 @@ export function createRouter(config: RouterConfig): ServerRoute['handler'] {
 						const response = new AgentResponseHandler();
 						const context = {
 							...config.context,
+							logger: config.context.logger.child({
+								'@agentuity/agentId': agentId,
+							}),
 							runId,
 							getAgent: (params: GetAgentRequestParams) =>
 								resolver.getAgent(params),


### PR DESCRIPTION
- Adds the otel SpanAttribute `@agentuity/agentId` to the context.logger for the agent
- Fix an issue with the base64 encoding output