### PR TITLE
Refactor to move everything to fully async HTTP native vs wrapped protocol

### DIFF
--- a/.changeset/lucky-houses-behave.md
+++ b/.changeset/lucky-houses-behave.md
@@ -1,0 +1,5 @@
+---
+"@agentuity/sdk": patch
+---
+
+Refactor to support binary streams instead of intermediate JSON protocol

--- a/.changeset/lucky-houses-behave.md
+++ b/.changeset/lucky-houses-behave.md
@@ -1,5 +1,0 @@
----
-"@agentuity/sdk": patch
----
-
-Refactor to support binary streams instead of intermediate JSON protocol

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,4 +17,4 @@ jobs:
         with:
           bun-version: 1.2.8
       - run: bun install
-      - run: bun test
+      - run: bun run test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @agentuity/sdk
 
+## 0.0.103
+
+### Patch Changes
+
+- 9f79163: Refactor to support binary streams instead of intermediate JSON protocol
+
 ## [0.0.102] - 2025-04-16
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@agentuity/sdk",
-	"version": "0.0.102",
+	"version": "0.0.103",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@agentuity/sdk",
-			"version": "0.0.102",
+			"version": "0.0.103",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/api": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -8,10 +8,7 @@
 	"main": "dist/index.js",
 	"module": "dist/index.js",
 	"type": "module",
-	"files": [
-		"dist/**/*",
-		"LICENSE.md"
-	],
+	"files": ["dist/**/*", "LICENSE.md"],
 	"engines": {
 		"node": ">=22"
 	},
@@ -24,17 +21,9 @@
 	"bugs": {
 		"url": "https://github.com/agenuity/sdk-js/issues"
 	},
-	"keywords": [
-		"ai",
-		"agents",
-		"agentuity",
-		"ai agent",
-		"agent"
-	],
+	"keywords": ["ai", "agents", "agentuity", "ai agent", "agent"],
 	"tsup": {
-		"entry": [
-			"src/index.ts"
-		],
+		"entry": ["src/index.ts"],
 		"format": "esm",
 		"splitting": false,
 		"sourcemap": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentuity/sdk",
-	"version": "0.0.102",
+	"version": "0.0.103",
 	"description": "The Agentuity SDK for NodeJS and Bun",
 	"license": "Apache-2.0",
 	"public": true,
@@ -8,7 +8,10 @@
 	"main": "dist/index.js",
 	"module": "dist/index.js",
 	"type": "module",
-	"files": ["dist/**/*", "LICENSE.md"],
+	"files": [
+		"dist/**/*",
+		"LICENSE.md"
+	],
 	"engines": {
 		"node": ">=22"
 	},
@@ -21,9 +24,17 @@
 	"bugs": {
 		"url": "https://github.com/agenuity/sdk-js/issues"
 	},
-	"keywords": ["ai", "agents", "agentuity", "ai agent", "agent"],
+	"keywords": [
+		"ai",
+		"agents",
+		"agentuity",
+		"ai agent",
+		"agent"
+	],
 	"tsup": {
-		"entry": ["src/index.ts"],
+		"entry": [
+			"src/index.ts"
+		],
 		"format": "esm",
 		"splitting": false,
 		"sourcemap": true,

--- a/src/router/request.ts
+++ b/src/router/request.ts
@@ -1,4 +1,10 @@
-import type { AgentRequest, Json, DataPayload } from '../types';
+import type { ReadableStream } from 'node:stream/web';
+import type {
+	AgentRequest,
+	Json,
+	DataPayload,
+	ReadableDataType,
+} from '../types';
 import { DataHandler } from './data';
 
 /**
@@ -8,9 +14,12 @@ export default class AgentRequestHandler implements AgentRequest {
 	private readonly request: DataPayload;
 	private readonly datahandler: DataHandler;
 
-	constructor(request: DataPayload) {
+	constructor(
+		request: DataPayload,
+		stream?: ReadableStream<ReadableDataType> | AsyncIterable<ReadableDataType>
+	) {
 		this.request = request;
-		this.datahandler = new DataHandler(request);
+		this.datahandler = new DataHandler(request, stream, request.contentType);
 	}
 
 	/**

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -222,6 +222,7 @@ export function createRouter(config: RouterConfig): ServerRoute['handler'] {
 					delete req.request.metadata['runid'];
 				}
 			}
+			req.request.runId = runId;
 		}
 		const logger = config.context.logger.child({
 			'@agentuity/agentId': agentId,
@@ -254,6 +255,11 @@ export function createRouter(config: RouterConfig): ServerRoute['handler'] {
 		try {
 			// Create a new context with the child span
 			const spanContext = trace.setSpan(currentContext, span);
+
+			if (!runId) {
+				runId = span.spanContext().traceId;
+				req.request.runId = runId;
+			}
 
 			executingCount++;
 

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -275,7 +275,7 @@ export function createRouter(config: RouterConfig): ServerRoute['handler'] {
 				},
 				async () => {
 					return await context.with(spanContext, async () => {
-						const request = new AgentRequestHandler(req.request);
+						const request = new AgentRequestHandler(req.request, req.body);
 						const response = new AgentResponseHandler();
 						const context = {
 							...config.context,
@@ -285,6 +285,7 @@ export function createRouter(config: RouterConfig): ServerRoute['handler'] {
 								resolver.getAgent(params),
 						} as AgentContext;
 						try {
+							await request.data.loadStream();
 							let handlerResponse = await config.handler(
 								request,
 								response,

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -211,7 +211,18 @@ export function createRouter(config: RouterConfig): ServerRoute['handler'] {
 
 	return async (req: ServerRequest): Promise<AgentResponseData> => {
 		const agentId = config.context.agent.id;
-		const runId = req.request.runId;
+		let runId = req.request.runId;
+		if (req.headers['x-agentuity-runid']) {
+			runId = req.headers['x-agentuity-runid'];
+			if (runId) {
+				// biome-ignore lint/performance/noDelete:
+				delete req.headers['x-agentuity-runid'];
+				if (req.request?.metadata?.['runid'] === runId) {
+					// biome-ignore lint/performance/noDelete:
+					delete req.request.metadata['runid'];
+				}
+			}
+		}
 		const logger = config.context.logger.child({
 			'@agentuity/agentId': agentId,
 			'@agentuity/agentName': config.context.agent.name,

--- a/src/server/bun.ts
+++ b/src/server/bun.ts
@@ -232,6 +232,7 @@ export class BunServer implements Server {
 										logger.debug('request: %s %s', method, url.pathname);
 
 										const isBinary = !!req.headers.get('x-agentuity-trigger');
+										const runId = span.spanContext().traceId;
 
 										try {
 											const routeResult = route.handler({
@@ -243,7 +244,7 @@ export class BunServer implements Server {
 												url: req.url,
 												headers: req.headers.toJSON(),
 												request: isBinary
-													? getRequestFromHeaders(req.headers.toJSON())
+													? getRequestFromHeaders(req.headers.toJSON(), runId)
 													: ((await req.json()) as IncomingRequest),
 												setTimeout: (val: number) =>
 													this.server?.timeout(req, val),

--- a/src/server/bun.ts
+++ b/src/server/bun.ts
@@ -4,6 +4,7 @@ import type {
 	ServerRoute,
 	IncomingRequest,
 } from './types';
+import type { ReadableStream } from 'node:stream/web';
 import { context, trace, SpanKind, SpanStatusCode } from '@opentelemetry/api';
 import {
 	extractTraceContextFromBunRequest,
@@ -14,8 +15,9 @@ import {
 	getRoutesHelpText,
 	createStreamingResponse,
 	toWelcomePrompt,
+	getRequestFromHeaders,
 } from './util';
-import type { AgentWelcomeResult } from '../types';
+import type { AgentWelcomeResult, ReadableDataType } from '../types';
 const idleTimeout = 255; // expressed in seconds
 const timeout = 600;
 
@@ -72,7 +74,12 @@ export class BunServer implements Server {
 						});
 					},
 				},
-				'/_health': new Response('OK'),
+				'/_health': new Response('OK', {
+					headers: {
+						'x-agentuity-binary': 'true',
+						'x-agentuity-version': sdkVersion,
+					},
+				}),
 				'/welcome': {
 					GET: async () => {
 						const result: Record<string, AgentWelcomeResult> = {};
@@ -179,21 +186,6 @@ export class BunServer implements Server {
 						const url = new URL(req.url);
 						const method = req.method;
 
-						if (method !== 'POST') {
-							return new Response('Method not allowed', {
-								status: 405,
-								headers: injectTraceContextToHeaders(),
-							});
-						}
-						if (!req.headers.get('content-type')?.includes('json')) {
-							return new Response(
-								'Invalid Content-Type, Expected application/json',
-								{
-									status: 400,
-									headers: injectTraceContextToHeaders(),
-								}
-							);
-						}
 						this.server?.timeout(req, timeout);
 
 						// Extract trace context from headers
@@ -201,8 +193,6 @@ export class BunServer implements Server {
 
 						// Execute the request handler within the extracted context
 						return context.with(extractedContext, async () => {
-							const body = await req.json();
-
 							// Create a span for this incoming request
 							return trace.getTracer('http-server').startActiveSpan(
 								`HTTP ${method}`,
@@ -241,20 +231,30 @@ export class BunServer implements Server {
 										span.setAttribute('@agentuity/agentId', route.agent.id);
 										logger.debug('request: %s %s', method, url.pathname);
 
+										const isBinary = !!req.headers.get('x-agentuity-trigger');
+
 										try {
 											const routeResult = route.handler({
+												body: isBinary
+													? ((req.body as unknown as
+															| ReadableStream<ReadableDataType>
+															| AsyncIterable<ReadableDataType>) ?? undefined)
+													: undefined,
 												url: req.url,
 												headers: req.headers.toJSON(),
-												request: body as IncomingRequest,
+												request: isBinary
+													? getRequestFromHeaders(req.headers.toJSON())
+													: ((await req.json()) as IncomingRequest),
 												setTimeout: (val: number) =>
 													this.server?.timeout(req, val),
 											});
 
-											const [headers, stream] = createStreamingResponse(
+											const [headers, stream] = await createStreamingResponse(
 												`Agentuity BunJS/${sdkVersion}`,
 												req.headers,
 												span,
-												routeResult
+												routeResult,
+												isBinary
 											);
 
 											return new Response(stream, {

--- a/src/server/node.ts
+++ b/src/server/node.ts
@@ -4,6 +4,7 @@ import type {
 	ServerRoute,
 	UnifiedServerConfig,
 } from './types';
+import type { ReadableStream } from 'node:stream/web';
 import type { Logger } from '../logger';
 import {
 	createServer as createHttpServer,
@@ -21,8 +22,10 @@ import {
 	getRoutesHelpText,
 	createStreamingResponse,
 	toWelcomePrompt,
+	getRequestFromHeaders,
 } from './util';
 import type { AgentWelcomeResult } from '../types';
+import { Readable } from 'node:stream';
 
 export const MAX_REQUEST_TIMEOUT = 60_000 * 10;
 
@@ -95,6 +98,24 @@ export class NodeServer implements Server {
 			});
 		});
 	}
+
+	private getBufferAsStream(
+		req: IncomingMessage
+	): Promise<ReadableStream<Buffer>> {
+		return new Promise((resolve, reject) => {
+			const chunks: Buffer[] = [];
+			req.on('data', (chunk) => chunks.push(chunk));
+			req.on('end', async () => {
+				const body = Buffer.concat(chunks);
+				const readable = Readable.from(body);
+				resolve(Readable.toWeb(readable) as ReadableStream<Buffer>);
+			});
+			req.on('error', (err) => {
+				reject(err);
+			});
+		});
+	}
+
 	/**
 	 * Gets the headers from the request
 	 */
@@ -117,7 +138,10 @@ export class NodeServer implements Server {
 		const { sdkVersion } = this;
 		this.server = createHttpServer(async (req, res) => {
 			if (req.method === 'GET' && req.url === '/_health') {
-				res.writeHead(200);
+				res.writeHead(200, {
+					'x-agentuity-binary': 'true',
+					'x-agentuity-version': sdkVersion,
+				});
 				res.end();
 				return;
 			}
@@ -227,7 +251,9 @@ export class NodeServer implements Server {
 					return;
 				}
 
-				if (!req.headers?.['content-type']?.includes('json')) {
+				const isBinary = !!req.headers?.['x-agentuity-trigger'];
+
+				if (!isBinary && !req.headers?.['content-type']?.includes('json')) {
 					res.writeHead(400, injectTraceContextToHeaders());
 					res.write('Invalid content type, expected application/json');
 					res.end();
@@ -235,12 +261,15 @@ export class NodeServer implements Server {
 				}
 
 				let payload: IncomingRequest;
-				try {
-					payload = await this.getJSON<IncomingRequest>(req);
-				} catch (err) {
-					this.logger.error('Error parsing request body as json: %s', err);
-					res.writeHead(400, injectTraceContextToHeaders());
-					res.end();
+				if (!isBinary) {
+					try {
+						payload = await this.getJSON<IncomingRequest>(req);
+					} catch (err) {
+						this.logger.error('Error parsing request body as json: %s', err);
+						res.writeHead(400, injectTraceContextToHeaders());
+						res.end();
+						return;
+					}
 				}
 
 				// Create a span for this incoming request
@@ -297,17 +326,25 @@ export class NodeServer implements Server {
 
 							try {
 								const agentReq = {
-									request: payload as IncomingRequest,
+									body: isBinary
+										? await this.getBufferAsStream(req)
+										: undefined,
+									request: isBinary
+										? getRequestFromHeaders(
+												req.headers as Record<string, string>
+											)
+										: (payload as IncomingRequest),
 									url: req.url ?? '',
 									headers: this.getHeaders(req),
 									setTimeout: (val: number) => req.setTimeout(val),
 								};
 								const routeResult = route.handler(agentReq);
-								const [headers, stream] = createStreamingResponse(
+								const [headers, stream] = await createStreamingResponse(
 									`Agentuity NodeJS/${sdkVersion}`,
 									new Headers(req.headers as Record<string, string>),
 									span,
-									routeResult
+									routeResult,
+									isBinary
 								);
 								res.writeHead(200, injectTraceContextToHeaders(headers));
 								// Ensure headers are sent before streaming
@@ -322,7 +359,11 @@ export class NodeServer implements Server {
 								res.end();
 							} catch (err) {
 								this.logger.error('Server error', err);
-								injectTraceContextToNodeResponse(res);
+								try {
+									injectTraceContextToNodeResponse(res);
+								} catch (err) {
+									this.logger.error('Error injecting trace context: %s', err);
+								}
 								res.writeHead(500);
 								res.end();
 								span.recordException(err as Error);

--- a/src/server/node.ts
+++ b/src/server/node.ts
@@ -322,6 +322,9 @@ export class NodeServer implements Server {
 
 							span.setAttribute('@agentuity/agentName', route.agent.name);
 							span.setAttribute('@agentuity/agentId', route.agent.id);
+
+							const runId = span.spanContext().traceId;
+
 							this.logger.debug('request: %s %s', req.method, req.url);
 
 							try {
@@ -331,7 +334,8 @@ export class NodeServer implements Server {
 										: undefined,
 									request: isBinary
 										? getRequestFromHeaders(
-												req.headers as Record<string, string>
+												req.headers as Record<string, string>,
+												runId
 											)
 										: (payload as IncomingRequest),
 									url: req.url ?? '',

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -1,9 +1,11 @@
 import type { Logger } from '../logger';
+import type { ReadableStream } from 'node:stream/web';
 import type {
 	AgentConfig,
 	DataPayload,
 	AgentResponseData,
 	AgentWelcome,
+	ReadableDataType,
 } from '../types';
 
 /**
@@ -22,6 +24,7 @@ export interface ServerRequest {
 	headers: Record<string, string>;
 	setTimeout: (val: number) => void;
 	controller?: ReadableStreamDefaultController;
+	body?: ReadableStream<ReadableDataType> | AsyncIterable<ReadableDataType>;
 }
 
 /**

--- a/src/server/util.ts
+++ b/src/server/util.ts
@@ -408,8 +408,10 @@ export async function createStreamingResponse(
 					const reader = resp.data.stream.getReader();
 					while (true) {
 						const { done, value } = await reader.read();
+						if (value) {
+							controller.enqueue(value);
+						}
 						if (done) break;
-						controller.enqueue(value);
 					}
 					controller.close();
 				},

--- a/src/server/util.ts
+++ b/src/server/util.ts
@@ -389,7 +389,15 @@ export async function createStreamingResponse(
 		const resp = await routeResult;
 		if (resp.metadata) {
 			for (const key in resp.metadata) {
-				responseheaders[`x-agentuity-${key}`] = resp.metadata[key] as string;
+				let value = resp.metadata[key] as string;
+				if (
+					value &&
+					value.charAt(0) === '{' &&
+					value.charAt(value.length - 1) === '}'
+				) {
+					value = safeParse(value, value);
+				}
+				responseheaders[`x-agentuity-${key}`] = value;
 			}
 		}
 		responseheaders['Content-Type'] = resp.data.contentType;

--- a/src/server/util.ts
+++ b/src/server/util.ts
@@ -476,7 +476,8 @@ export async function createStreamingResponse(
 }
 
 export function getRequestFromHeaders(
-	headers: Record<string, string>
+	headers: Record<string, string>,
+	runId: string
 ): IncomingRequest {
 	let trigger: TriggerType = 'manual';
 	const metadata: Record<string, string> = {};
@@ -491,10 +492,10 @@ export function getRequestFromHeaders(
 		}
 	}
 	return {
-		trigger,
-		metadata,
 		contentType: headers['content-type'] ?? 'application/octet-stream',
+		metadata,
 		payload: '',
-		runId: '',
+		runId,
+		trigger,
 	};
 }

--- a/src/server/util.ts
+++ b/src/server/util.ts
@@ -483,7 +483,7 @@ export function getRequestFromHeaders(
 	return {
 		trigger,
 		metadata,
-		contentType: headers['content-type'] ?? 'application/json',
+		contentType: headers['content-type'] ?? 'application/octet-stream',
 		payload: '',
 		runId: '',
 	};

--- a/src/server/util.ts
+++ b/src/server/util.ts
@@ -12,7 +12,7 @@ import type {
 	AgentWelcomePrompt,
 } from '../types';
 import { injectTraceContextToHeaders } from './otel';
-import type { ServerRoute } from './types';
+import type { IncomingRequest, ServerRoute } from './types';
 
 export function safeStringify(obj: unknown) {
 	const seen = new WeakSet();
@@ -360,12 +360,13 @@ export class Base64StreamHelper {
 	}
 }
 
-export function createStreamingResponse(
+export async function createStreamingResponse(
 	server: string,
 	headers: Headers,
 	span: Span,
-	routeResult: Promise<AgentResponseData>
-): [Record<string, string>, ReadableStream] {
+	routeResult: Promise<AgentResponseData>,
+	binary?: boolean
+): Promise<[Record<string, string>, ReadableStream]> {
 	const responseheaders = injectTraceContextToHeaders({
 		Server: server,
 	});
@@ -379,11 +380,36 @@ export function createStreamingResponse(
 		responseheaders['X-Accel-Buffering'] = 'no';
 		span.setAttribute('http.sse', 'true');
 	} else {
-		responseheaders['Content-Type'] = 'application/json';
 		span.setAttribute('http.sse', 'false');
 	}
 	span.setAttribute('http.status_code', '200');
 	span.setStatus({ code: SpanStatusCode.OK });
+	// binary is the new protocol for streaming
+	if (binary) {
+		const resp = await routeResult;
+		if (resp.metadata) {
+			for (const key in resp.metadata) {
+				responseheaders[`x-agentuity-${key}`] = resp.metadata[key] as string;
+			}
+		}
+		responseheaders['Content-Type'] = resp.data.contentType;
+		return [
+			responseheaders,
+			new ReadableStream({
+				async start(controller) {
+					const reader = resp.data.stream.getReader();
+					while (true) {
+						const { done, value } = await reader.read();
+						if (done) break;
+						controller.enqueue(value);
+					}
+					controller.close();
+				},
+			}),
+		];
+	}
+	// this is the old protocol for streaming which will be deprecated and removed in a future version
+	responseheaders['Content-Type'] = 'application/json';
 	return [
 		responseheaders,
 		new ReadableStream({
@@ -437,4 +463,28 @@ export function createStreamingResponse(
 			},
 		}),
 	];
+}
+
+export function getRequestFromHeaders(
+	headers: Record<string, string>
+): IncomingRequest {
+	let trigger: TriggerType = 'manual';
+	const metadata: Record<string, string> = {};
+	for (const [key, value] of Object.entries(headers)) {
+		if (key.startsWith('x-agentuity-')) {
+			const name = key.slice(12);
+			if (name === 'trigger') {
+				trigger = value as TriggerType;
+			} else {
+				metadata[name] = value;
+			}
+		}
+	}
+	return {
+		trigger,
+		metadata,
+		contentType: headers['content-type'] ?? 'application/json',
+		payload: '',
+		runId: '',
+	};
 }


### PR DESCRIPTION
Add support for new binary protocol which is vanilla HTTP streaming instead of the current JSON protocol.

This will allow us to move to fully async, bi-directional streaming.