### PR TITLE
Add support for remote agent handoff

### DIFF
--- a/.changeset/beige-plants-check.md
+++ b/.changeset/beige-plants-check.md
@@ -1,0 +1,5 @@
+---
+"@agentuity/sdk": patch
+---
+
+Add support for remote agent handoff

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -24,7 +24,6 @@ import AgentRequestHandler from './request';
 import AgentResponseHandler from './response';
 import type { Logger } from '../logger';
 import AgentResolver from '../server/agents';
-import { DataHandler } from './data';
 
 interface RouterConfig {
 	handler: AgentHandler;
@@ -347,10 +346,7 @@ export function createRouter(config: RouterConfig): ServerRoute['handler'] {
 									[redirect.invocation ?? req.request]
 								);
 								span.setStatus({ code: SpanStatusCode.OK });
-								return {
-									data: new DataHandler(redirectResponse),
-									metadata: redirectResponse.metadata,
-								};
+								return redirectResponse;
 							}
 
 							span.setStatus({ code: SpanStatusCode.OK });

--- a/src/server/agents.ts
+++ b/src/server/agents.ts
@@ -301,7 +301,11 @@ export default class AgentResolver {
 			if ('id' in params && a.id === params.id) {
 				return a;
 			}
-			if ('name' in params && a.name === params.name) {
+			if (
+				'name' in params &&
+				a.name === params.name &&
+				(this.projectId === params.projectId || !params.projectId)
+			) {
 				return a;
 			}
 			return null;
@@ -309,7 +313,7 @@ export default class AgentResolver {
 		if (agent) {
 			if (agent.id === this.currentAgentId) {
 				throw new Error(
-					'agent loop detected trying to redirect to the current active agent'
+					'agent loop detected trying to redirect to the current active agent. if you are trying to redirect to another agent in a different project with the same name, you must specify the projectId parameter along with the name parameter'
 				);
 			}
 			return new LocalAgentInvoker(

--- a/src/types.ts
+++ b/src/types.ts
@@ -317,11 +317,6 @@ export interface RemoteAgent {
 	name: string;
 
 	/**
-	 * the description of the agent
-	 */
-	description?: string;
-
-	/**
 	 * the project id of the agent
 	 */
 	projectId: string;


### PR DESCRIPTION
Adds support for handing off a request to a remote agent.

## Examples:

### By ID

```typescript
return resp.handoff({
  id: 'agent_9e478ebc1b6b58f921725e2f6f0025ab',
})
```

### By Name

```typescript
return resp.handoff({
  name: 'my agent',
})
```

### By Name Scoped to a Project

```typescript
return resp.handoff({
  name: 'my agent',
  projectId: 'proj_fc9a68c544c486cebf982c9843b9032b',
})
```
