### PR TITLE
Add the ability for an agent to return a Response object directly to provide more flexibility to integrate with existing APIs and protocols

### DIFF
--- a/.changeset/cruel-webs-dance.md
+++ b/.changeset/cruel-webs-dance.md
@@ -1,0 +1,5 @@
+---
+"@agentuity/sdk": patch
+---
+
+Add the ability for an agent to return a Response object directly to provide more flexibility to integrate with existing APIs and protocols

--- a/package.json
+++ b/package.json
@@ -8,10 +8,7 @@
 	"main": "dist/index.js",
 	"module": "dist/index.js",
 	"type": "module",
-	"files": [
-		"dist/**/*",
-		"LICENSE.md"
-	],
+	"files": ["dist/**/*", "LICENSE.md"],
 	"engines": {
 		"node": ">=22"
 	},
@@ -24,17 +21,9 @@
 	"bugs": {
 		"url": "https://github.com/agenuity/sdk-js/issues"
 	},
-	"keywords": [
-		"ai",
-		"agents",
-		"agentuity",
-		"ai agent",
-		"agent"
-	],
+	"keywords": ["ai", "agents", "agentuity", "ai agent", "agent"],
 	"tsup": {
-		"entry": [
-			"src/index.ts"
-		],
+		"entry": ["src/index.ts"],
 		"format": "esm",
 		"splitting": false,
 		"sourcemap": true,
@@ -51,7 +40,7 @@
 		"version": "npx @changesets/cli version",
 		"release": "npm run build && npx @changesets/cli publish && git push --follow-tags",
 		"start": "npm run node:start",
-		"test": "for t in `find ./test -name '*.test.ts'`;do bun test $t; done;"
+		"test": "for t in `find ./test -name '*.test.ts'`;do bun test $t || exit 1; done;"
 	},
 	"exports": {
 		"./package.json": "./package.json",

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -35,7 +35,7 @@ export interface ServerRequest {
 export interface ServerRoute {
 	path: string;
 	method: 'GET' | 'POST' | 'PUT' | 'DELETE';
-	handler: (req: ServerRequest) => Promise<AgentResponseData>;
+	handler: (req: ServerRequest) => Promise<AgentResponseData | Response>;
 	agent: AgentConfig;
 	welcome?: AgentWelcome;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -146,7 +146,13 @@ export interface DataResultNotFound {
 export type DataResult = DataResultFound | DataResultNotFound;
 
 export interface KeyValueStorageSetParams {
+	/**
+	 * the number of milliseconds to keep the value in the cache
+	 */
 	ttl?: number;
+	/**
+	 * the content type of the value
+	 */
 	contentType?: string;
 }
 
@@ -299,13 +305,28 @@ export interface VectorStorage {
 }
 
 export interface InvocationArguments {
+	/**
+	 * the data to pass to the agent
+	 */
 	data?: DataType;
+	/**
+	 * the content type of the data
+	 */
 	contentType?: string;
+	/**
+	 * the metadata to pass to the agent
+	 */
 	metadata?: JsonObject;
 }
 
 export interface RemoteAgentResponse {
+	/**
+	 * the response data from the agent
+	 */
 	data: Data;
+	/**
+	 * the metadata from the agent
+	 */
 	metadata?: JsonObject;
 }
 
@@ -459,13 +480,28 @@ export interface AgentRequest {
 }
 
 export interface AgentResponseData {
+	/**
+	 * the data from the agent
+	 */
 	data: Data;
+	/**
+	 * the metadata from the agent
+	 */
 	metadata?: JsonObject;
 }
 
 export interface AgentRedirectResponse {
+	/**
+	 * if this is a redirect response
+	 */
 	redirect: true;
+	/**
+	 * the agent to redirect to
+	 */
 	agent: GetAgentRequestParams;
+	/**
+	 * the invocation arguments
+	 */
 	invocation?: InvocationArguments;
 }
 
@@ -572,6 +608,11 @@ export interface AgentResponse {
 
 	/**
 	 * return a response with specific data and content type with optional metadata
+	 *
+	 * @param data - the data to return
+	 * @param contentType - the content type of the data
+	 * @param metadata - the metadata to return
+	 * @returns the response data
 	 */
 	data(
 		data: DataType,
@@ -585,7 +626,12 @@ export interface AgentResponse {
 	markdown(content: string, metadata?: JsonObject): Promise<AgentResponseData>;
 
 	/**
-	 * stream a response to the client. the content type will default to text/plain if not provided or if SSE is requested.
+	 * stream a response to the client. the content type will default to application/octet-stream if not provided.
+	 *
+	 * @param stream - the stream to return
+	 * @param contentType - the content type of the stream
+	 * @param metadata - the metadata to return as headers
+	 * @returns the response data
 	 */
 	stream(
 		stream: ReadableStream<ReadableDataType> | AsyncIterable<ReadableDataType>,
@@ -601,7 +647,7 @@ export type AgentHandler = (
 	request: AgentRequest,
 	response: AgentResponse,
 	context: AgentContext
-) => Promise<AgentResponseData>;
+) => Promise<AgentResponseData | Response>;
 
 export interface AgentWelcomePrompt {
 	/**
@@ -658,12 +704,27 @@ export interface AgentConfig {
  * Session information for an agent request
  */
 export interface Session {
+	/**
+	 * the request
+	 */
 	request: AgentRequest;
+	/**
+	 * the context
+	 */
 	context: AgentContext;
 }
 
 export interface DataPayload {
+	/**
+	 * the trigger that caused the invocation
+	 */
 	trigger: TriggerType;
+	/**
+	 * the content type
+	 */
 	contentType: string;
+	/**
+	 * the metadata
+	 */
 	metadata?: JsonObject;
 }

--- a/test/apis/keyvalue-compression.test.ts
+++ b/test/apis/keyvalue-compression.test.ts
@@ -163,7 +163,13 @@ describe('KeyValue API Compression', () => {
 						},
 					},
 					response: {
-						arrayBuffer: () => Promise.resolve(Buffer.from('compressed-data')),
+						arrayBuffer: () =>
+							Promise.resolve(
+								Buffer.from(
+									'H4sICGUADWgAA3Rlc3QudHh0APPI5AIAmjwi1QMAAAA=',
+									'base64'
+								)
+							),
 					},
 				})
 			);

--- a/test/server/gzip.test.ts
+++ b/test/server/gzip.test.ts
@@ -63,13 +63,13 @@ describe('Compression Utilities', () => {
 			const compressed = await gzipString(testString);
 			const decompressed = await gunzipBuffer(compressed);
 
-			expect(decompressed).toBe(testString);
+			expect(decompressed.toString('utf-8')).toBe(testString);
 		});
 
 		it('should return an empty string for empty buffer', async () => {
 			const decompressed = await gunzipBuffer(Buffer.from([]));
 
-			expect(decompressed).toBe('');
+			expect(decompressed.length).toBe(0);
 		});
 
 		it('should throw an error for invalid gzip data', async () => {
@@ -84,8 +84,8 @@ describe('Compression Utilities', () => {
 				undefined as unknown as Buffer
 			);
 
-			expect(decompressedNull).toBe('');
-			expect(decompressedUndefined).toBe('');
+			expect(decompressedNull.length).toBe(0);
+			expect(decompressedUndefined.length).toBe(0);
 		});
 	});
 
@@ -95,7 +95,7 @@ describe('Compression Utilities', () => {
 			const compressed = await gzipString(testString);
 			const decompressed = await gunzipBuffer(compressed);
 
-			expect(decompressed).toBe(testString);
+			expect(decompressed.toString('utf-8')).toBe(testString);
 		});
 
 		it('should correctly roundtrip a large string', async () => {
@@ -103,7 +103,7 @@ describe('Compression Utilities', () => {
 			const compressed = await gzipString(largeString);
 			const decompressed = await gunzipBuffer(compressed);
 
-			expect(decompressed).toBe(largeString);
+			expect(decompressed.toString('utf-8')).toBe(largeString);
 		});
 
 		it('should correctly roundtrip a JSON string', async () => {
@@ -120,8 +120,8 @@ describe('Compression Utilities', () => {
 			const compressed = await gzipString(jsonString);
 			const decompressed = await gunzipBuffer(compressed);
 
-			expect(decompressed).toBe(jsonString);
-			expect(JSON.parse(decompressed)).toEqual(jsonObject);
+			expect(decompressed.toString('utf-8')).toBe(jsonString);
+			expect(JSON.parse(decompressed.toString('utf-8'))).toEqual(jsonObject);
 		});
 
 		it('should correctly roundtrip Unicode strings', async () => {
@@ -129,7 +129,7 @@ describe('Compression Utilities', () => {
 			const compressed = await gzipString(unicodeString);
 			const decompressed = await gunzipBuffer(compressed);
 
-			expect(decompressed).toBe(unicodeString);
+			expect(decompressed.toString('utf-8')).toBe(unicodeString);
 		});
 	});
 });


### PR DESCRIPTION
Add the ability for an agent to return a Response object directly to provide more flexibility to integrate with existing APIs and protocols

This provides the ability for something like this from the Vercel AI SDK:


```typescript
import type { AgentRequest, AgentResponse, AgentContext } from "@agentuity/sdk";
import { createDataStreamResponse, streamText, type UIMessage } from "ai";
import { openai } from "@ai-sdk/openai";

export default async function Agent(
	req: AgentRequest,
	resp: AgentResponse,
	ctx: AgentContext,
) {
	const {
		id,
		messages,
	}: {
		id: string;
		messages: Array<UIMessage>;
	} = await req.data.object();

	return createDataStreamResponse({
		execute: (dataStream) => {
			const result = streamText({
				model: openai("gpt-4o"),
				system: "you are a helpful assistant",
				messages,
				maxSteps: 5,
			});

			result.consumeStream();

			result.mergeIntoDataStream(dataStream, {
				sendReasoning: true,
			});
		},
		onError: (err) => {
			console.error(err);
			return "Oops, an error occurred!";
		},
	});
}
```