### PR TITLE
Bind explicitly to ipv4 when creating server

### DIFF
--- a/.changeset/swift-rockets-work.md
+++ b/.changeset/swift-rockets-work.md
@@ -1,0 +1,5 @@
+---
+"@agentuity/sdk": patch
+---
+
+Bind explicitly to ipv4 when creating server

--- a/src/server/bun.ts
+++ b/src/server/bun.ts
@@ -54,12 +54,13 @@ export class BunServer implements Server {
 
 		this.server = Bun.serve({
 			port: this.config.port,
+			hostname: '127.0.0.1',
 			idleTimeout: idleTimeout,
 			routes: {
 				'/': {
 					GET: async (req) => {
 						const helpText = getRoutesHelpText(
-							req.headers.get('host') ?? 'localhost:3500',
+							req.headers.get('host') ?? '127.0.0.1:3500',
 							this.config.routes
 						);
 						return new Response(helpText, {

--- a/src/server/node.ts
+++ b/src/server/node.ts
@@ -129,7 +129,7 @@ export class NodeServer implements Server {
 					'Content-Type': 'text/plain',
 				});
 				res.end(
-					getRoutesHelpText(req.headers.host ?? 'localhost:3500', this.routes)
+					getRoutesHelpText(req.headers.host ?? '127.0.0.1:3500', this.routes)
 				);
 				return;
 			}
@@ -340,7 +340,7 @@ export class NodeServer implements Server {
 			const server = this.server as ReturnType<typeof createHttpServer>;
 			server.requestTimeout = MAX_REQUEST_TIMEOUT;
 			server.timeout = MAX_REQUEST_TIMEOUT;
-			server.listen(this.port, () => {
+			server.listen(this.port, '127.0.0.1', () => {
 				this.logger.info(`Node server listening on port ${this.port}`);
 				resolve();
 			});

--- a/test/server/util.test.ts
+++ b/test/server/util.test.ts
@@ -87,14 +87,14 @@ describe('Utility Functions', () => {
 				},
 			];
 
-			const result = getRoutesHelpText('localhost:3000', routes);
+			const result = getRoutesHelpText('127.0.0.1:3000', routes);
 			expect(result).toContain('The following Agent routes are available:');
 			expect(result).toContain('GET /test [TestAgent]');
 			expect(result).toContain('POST /another [AnotherAgent]');
 
 			if (process.platform === 'darwin' || process.platform === 'linux') {
 				expect(result).toContain('Example usage:');
-				expect(result).toContain('curl http://localhost:3000/test');
+				expect(result).toContain('curl http://127.0.0.1:3000/test');
 			}
 		});
 	});


### PR DESCRIPTION
Seems like macos has dual stack support turned off by default but windows has dual stack on by default (ipv4 and v6).  using localhost in some cases seems to resolve to `[::]` which is the ipv6 address when trying to hit the agent locally in some cases.