### PR TITLE
cross platform support for headers.toJSON

### DIFF
--- a/src/server/agents.ts
+++ b/src/server/agents.ts
@@ -14,6 +14,7 @@ import {
 	metadataFromHeaders,
 	setMetadataInHeaders,
 	dataTypeToBuffer,
+	headersToRecord,
 } from './util';
 import { injectTraceContextToHeaders } from './otel';
 import { DataHandler } from '../router/data';
@@ -100,7 +101,7 @@ class LocalAgentInvoker implements RemoteAgent {
 							),
 							contentType:
 								resp.headers.get('content-type') ?? 'application/octet-stream',
-							metadata: metadataFromHeaders(resp.headers.toJSON()),
+							metadata: metadataFromHeaders(headersToRecord(resp.headers)),
 						};
 					}
 				}
@@ -215,7 +216,7 @@ class RemoteAgentInvoker implements RemoteAgent {
 					});
 					throw new Error(await resp.text());
 				}
-				const metadata = metadataFromHeaders(resp.headers.toJSON());
+				const metadata = metadataFromHeaders(headersToRecord(resp.headers));
 				const contentType =
 					resp.headers.get('content-type') ?? 'application/octet-stream';
 				this.logger.debug(

--- a/src/server/util.ts
+++ b/src/server/util.ts
@@ -430,3 +430,17 @@ export function setMetadataInHeaders(
 		}
 	}
 }
+
+export function headersToRecord(headers: Headers): Record<string, string> {
+	// Try using toJSON if available
+	if (typeof headers.toJSON === 'function') {
+		return headers.toJSON();
+	}
+
+	// Fallback for environments where toJSON is not available
+	const record: Record<string, string> = {};
+	headers.forEach((value, key) => {
+		record[key] = value;
+	});
+	return record;
+}

--- a/test/server/crossPlatform.test.ts
+++ b/test/server/crossPlatform.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, mock } from 'bun:test';
+import AgentResolver from '../../src/server/agents';
+import { ReadableStream } from 'node:stream/web';
+import '../setup'; // Import global test setup
+import { mockOpenTelemetry } from '../mocks/opentelemetry';
+import * as router from '../../src/router/router';
+
+// Mock the router module to prevent "no store" error
+mock.module('../../src/router/router', () => {
+	return {
+		...router,
+		getTracer: () => ({
+			startSpan: () => ({
+				end: () => {},
+				setAttribute: () => {},
+				setStatus: () => {},
+				recordException: () => {},
+			}),
+		}),
+		recordException: () => {},
+		getSDKVersion: () => 'test',
+	};
+});
+
+// Setup OpenTelemetry mocks
+mockOpenTelemetry();
+
+describe('Cross-platform compatibility', () => {
+	const mockLogger = {
+		debug: mock(() => {}),
+		info: mock(() => {}),
+		warn: mock(() => {}),
+		error: mock(() => {}),
+		child: mock(() => mockLogger),
+	};
+
+	let originalFetch: typeof globalThis.fetch;
+	let mockResponseBody: ReadableStream;
+
+	it('should handle headers object without toJSON method', async () => {
+		// Save the original fetch
+		originalFetch = globalThis.fetch;
+
+		try {
+			// Create a mock response body
+			mockResponseBody = new ReadableStream({
+				start(controller) {
+					const encoder = new TextEncoder();
+					controller.enqueue(
+						encoder.encode(JSON.stringify({ message: 'Hello from agent' }))
+					);
+					controller.close();
+				},
+			});
+
+			// Create a mock Headers implementation without toJSON method
+			// Using a plain object that mimics Headers API but without toJSON
+			const mockHeaders = {
+				get: (name: string) => {
+					if (name.toLowerCase() === 'content-type') return 'application/json';
+					if (name.toLowerCase() === 'x-agentuity-responseid') return '12345';
+					return null;
+				},
+				has: (name: string) => {
+					return (
+						name.toLowerCase() === 'content-type' ||
+						name.toLowerCase() === 'x-agentuity-responseid'
+					);
+				},
+				forEach: (callback: (value: string, key: string) => void) => {
+					callback('application/json', 'content-type');
+					callback('12345', 'x-agentuity-responseid');
+				},
+				// Intentionally no toJSON method
+			};
+
+			// Ensure toJSON is really not available
+			expect('toJSON' in mockHeaders).toBe(false);
+
+			// Create a selective mock fetch that only intercepts requests to our agent
+			// This way, other tests that might run in parallel won't be affected
+			globalThis.fetch = mock(
+				(url: string | URL | Request, init?: RequestInit) => {
+					// Convert url to string if it's not already
+					const urlString =
+						url instanceof URL
+							? url.toString()
+							: url instanceof Request
+								? url.url
+								: url;
+
+					// Only intercept requests to our test agent
+					if (urlString.includes('test-agent-id')) {
+						return Promise.resolve({
+							ok: true,
+							status: 200,
+							statusText: 'OK',
+							headers: mockHeaders,
+							body: mockResponseBody,
+						} as Response);
+					}
+
+					// For all other URLs, use the original fetch
+					return originalFetch(url, init);
+				}
+			);
+
+			const agents = [
+				{
+					id: 'test-agent-id',
+					name: 'Test Agent',
+					filename: 'agent-path',
+					description: 'Test Agent description',
+				},
+			];
+
+			const resolver = new AgentResolver(
+				mockLogger,
+				agents,
+				3000,
+				'project-id',
+				'current-agent-id'
+			);
+
+			// Get the agent
+			const agent = await resolver.getAgent({ id: 'test-agent-id' });
+
+			// Run the agent - this would fail before our fix
+			const response = await agent.run({
+				data: 'Test input data',
+				contentType: 'text/plain',
+			});
+
+			// Verify data content
+			const jsonData = await response.data.json();
+			expect(jsonData).toEqual({ message: 'Hello from agent' });
+		} finally {
+			// Always restore the original fetch, even if the test fails
+			globalThis.fetch = originalFetch;
+		}
+	});
+});


### PR DESCRIPTION
Not all platforms, specifically bun doesn't natively support toJSON() for headers.   This change will use toJson when it exists and implements a fallback when it is missing.

This addresses this issue: #103 