### PR TITLE
Fixed issue with Vector get having the wrong return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @agentuity/sdk Changelog
 
+## 0.0.114
+
+### Patch Changes
+
+- Fixed issue with Vector get type being wrong
+
 ## 0.0.113
 
 ### Patch Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@agentuity/sdk",
-	"version": "0.0.113",
+	"version": "0.0.114",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@agentuity/sdk",
-			"version": "0.0.113",
+			"version": "0.0.114",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/api": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentuity/sdk",
-	"version": "0.0.113",
+	"version": "0.0.114",
 	"description": "The Agentuity SDK for NodeJS and Bun",
 	"license": "Apache-2.0",
 	"public": true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -280,7 +280,7 @@ export interface VectorStorage {
 	 * @param key - the key of the vector to get
 	 * @returns the results of the vector search
 	 */
-	get(name: string, key: string): Promise<VectorSearchResult[]>;
+	get(name: string, key: string): Promise<VectorSearchResult | null>;
 
 	/**
 	 * search for vectors in the vector storage


### PR DESCRIPTION
Should return either a document or null instead of an array