### PR TITLE
Fixed issue where empty POST body would cause a hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @agentuity/sdk Changelog
 
+## 0.0.116
+
+### Patch Changes
+
+- Fixed issue where empty POST body would cause a hang
+
 ## 0.0.115
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@agentuity/sdk",
-	"version": "0.0.114",
+	"version": "0.0.116",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@agentuity/sdk",
-			"version": "0.0.114",
+			"version": "0.0.116",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/api": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentuity/sdk",
-	"version": "0.0.115",
+	"version": "0.0.116",
 	"description": "The Agentuity SDK for NodeJS and Bun",
 	"license": "Apache-2.0",
 	"public": true,

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -188,6 +188,14 @@ async function agentRedirectRun(
 	}
 }
 
+function createEmptyStream() {
+	return new ReadableStream({
+		start(controller) {
+			controller.close();
+		},
+	});
+}
+
 /**
  * Creates a router handler for the specified configuration
  *
@@ -294,7 +302,7 @@ export function createRouter(config: RouterConfig): ServerRoute['handler'] {
 					return await context.with(spanContext, async () => {
 						const body = req.body
 							? (req.body as unknown as ReadableStream<ReadableDataType>)
-							: new ReadableStream<ReadableDataType>();
+							: createEmptyStream();
 						const request = new AgentRequestHandler(
 							req.request.trigger,
 							body,


### PR DESCRIPTION
When you send a POST with no body (which is normal) to an Agent, it will hang.

The reason is that the body was null and an empty ReadableStream was created by never closed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where sending an empty POST request body could cause the system to hang.

- **Chores**
  - Updated the application version to 0.0.116 in the changelog and package information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->