### PR TITLE
[AGENT-33] Better Type inference for metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @agentuity/sdk Changelog
 
+## 0.0.117
+
+### Patch Changes
+
+- Better type handling for metadata where can be any valid JSON object
+
 ## 0.0.116
 
 ### Patch Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@agentuity/sdk",
-	"version": "0.0.116",
+	"version": "0.0.117",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@agentuity/sdk",
-			"version": "0.0.116",
+			"version": "0.0.117",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/api": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentuity/sdk",
-	"version": "0.0.116",
+	"version": "0.0.117",
 	"description": "The Agentuity SDK for NodeJS and Bun",
 	"license": "Apache-2.0",
 	"public": true,

--- a/src/apis/keyvalue.ts
+++ b/src/apis/keyvalue.ts
@@ -2,10 +2,10 @@ import type {
 	DataResult,
 	DataResultFound,
 	DataResultNotFound,
-	DataType,
 	KeyValueStorage,
 	KeyValueStorageSetParams,
 } from '../types';
+import { isDataType } from '../types';
 import { DELETE, GET, PUT } from './api';
 import { getTracer, recordException } from '../router/router';
 import { context, trace, SpanStatusCode } from '@opentelemetry/api';
@@ -85,12 +85,16 @@ export default class KeyValueAPI implements KeyValueStorage {
 	 * @param value - the value to set
 	 * @param ttl - the time to live of the key
 	 */
-	async set(
+	async set<T = unknown>(
 		name: string,
 		key: string,
-		value: DataType,
+		value: T,
 		params?: KeyValueStorageSetParams
 	): Promise<void> {
+		if (!isDataType(value)) {
+			throw new Error('value must be a DataType');
+		}
+
 		const tracer = getTracer();
 		const currentContext = context.active();
 

--- a/src/apis/vector.ts
+++ b/src/apis/vector.ts
@@ -4,6 +4,7 @@ import type {
 	VectorSearchParams,
 	VectorSearchResult,
 } from '../types';
+import { isJsonObject } from '../types';
 import { DELETE, GET, POST, PUT } from './api';
 import { getTracer, recordException } from '../router/router';
 import { context, trace, SpanStatusCode } from '@opentelemetry/api';
@@ -213,10 +214,13 @@ export default class VectorAPI implements VectorStorage {
 	 * @param params - the parameters for the vector search
 	 * @returns the results of the vector search
 	 */
-	async search(
+	async search<T = unknown>(
 		name: string,
-		params: VectorSearchParams
+		params: VectorSearchParams<T>
 	): Promise<VectorSearchResult[]> {
+		if (!isJsonObject(params.metadata)) {
+			throw new Error('params.metadata must be a JsonObject');
+		}
 		const tracer = getTracer();
 		const currentContext = context.active();
 

--- a/src/router/response.ts
+++ b/src/router/response.ts
@@ -2,13 +2,13 @@ import type {
 	AgentResponse,
 	InvocationArguments,
 	GetAgentRequestParams,
-	Json,
 	AgentResponseData,
 	JsonObject,
 	DataType,
 	AgentRedirectResponse,
 	ReadableDataType,
 } from '../types';
+import { isJsonObject } from '../types';
 import type { ReadableStream } from 'node:stream/web';
 import { DataHandler } from './data';
 import { safeStringify, fromDataType } from '../server/util';
@@ -21,184 +21,265 @@ export default class AgentResponseHandler implements AgentResponse {
 	/**
 	 * redirect the current request another agent within the same project
 	 */
-	async handoff(
+	async handoff<M = unknown>(
 		agent: GetAgentRequestParams,
 		args?: InvocationArguments
 	): Promise<AgentRedirectResponse> {
-		const result: AgentRedirectResponse = {
-			redirect: true,
-			agent,
-			invocation: args,
-		};
-		return result;
+		if (isJsonObject(args?.metadata)) {
+			const result: AgentRedirectResponse = {
+				redirect: true,
+				agent,
+				invocation: args as JsonObject,
+			};
+			return result;
+		}
+		throw new Error('metadata must be a JsonObject');
 	}
 
 	/**
 	 * return an empty response with optional metadata
 	 */
-	async empty(metadata?: JsonObject): Promise<AgentResponseData> {
-		return {
-			data: new DataHandler('', 'text/plain'),
-			metadata,
-		};
+	async empty<M = unknown>(metadata?: M): Promise<AgentResponseData> {
+		if (isJsonObject(metadata)) {
+			return {
+				data: new DataHandler('', 'text/plain'),
+				metadata,
+			};
+		}
+		throw new Error('metadata must be a JsonObject');
 	}
 
 	/**
 	 * return a JSON response with optional metadata
 	 */
-	async json(data: Json, metadata?: JsonObject): Promise<AgentResponseData> {
-		return {
-			data: new DataHandler(safeStringify(data), 'application/json'),
-			metadata,
-		};
+	async json<T = unknown, M = unknown>(
+		data: T,
+		metadata?: M
+	): Promise<AgentResponseData> {
+		if (!isJsonObject(data)) {
+			throw new Error('data must be a JsonObject');
+		}
+		if (isJsonObject(metadata)) {
+			return {
+				data: new DataHandler(safeStringify(data), 'application/json'),
+				metadata,
+			};
+		}
+		throw new Error('metadata must be a JsonObject');
 	}
 
 	/**
 	 * return a text response with optional metadata
 	 */
-	async text(data: string, metadata?: JsonObject): Promise<AgentResponseData> {
-		return {
-			data: new DataHandler(data, 'text/plain'),
-			metadata,
-		};
+	async text<M = unknown>(
+		data: string,
+		metadata?: M
+	): Promise<AgentResponseData> {
+		if (isJsonObject(metadata)) {
+			return {
+				data: new DataHandler(data, 'text/plain'),
+				metadata,
+			};
+		}
+		throw new Error('metadata must be a JsonObject');
 	}
 
 	/**
 	 * return a binary response with optional metadata
 	 */
-	binary(data: DataType, metadata?: JsonObject): Promise<AgentResponseData> {
-		return fromDataType(data, 'application/octet-stream', metadata);
+	binary<M = unknown>(
+		data: DataType,
+		metadata?: M
+	): Promise<AgentResponseData> {
+		if (isJsonObject(metadata)) {
+			return fromDataType(data, 'application/octet-stream', metadata);
+		}
+		throw new Error('metadata must be a JsonObject');
 	}
 
 	/**
 	 * return a PDF response with optional metadata
 	 */
-	pdf(data: DataType, metadata?: JsonObject): Promise<AgentResponseData> {
-		return fromDataType(data, 'application/pdf', metadata);
+	pdf<M = unknown>(data: DataType, metadata?: M): Promise<AgentResponseData> {
+		if (isJsonObject(metadata)) {
+			return fromDataType(data, 'application/pdf', metadata);
+		}
+		throw new Error('metadata must be a JsonObject');
 	}
 
 	/**
 	 * return a PNG response with optional metadata
 	 */
-	png(data: DataType, metadata?: JsonObject): Promise<AgentResponseData> {
-		return fromDataType(data, 'image/png', metadata);
+	png<M = unknown>(data: DataType, metadata?: M): Promise<AgentResponseData> {
+		if (isJsonObject(metadata)) {
+			return fromDataType(data, 'image/png', metadata);
+		}
+		throw new Error('metadata must be a JsonObject');
 	}
 
 	/**
 	 * return a JPEG response with optional metadata
 	 */
-	jpeg(data: DataType, metadata?: JsonObject): Promise<AgentResponseData> {
-		return fromDataType(data, 'image/jpeg', metadata);
+	jpeg<M = unknown>(data: DataType, metadata?: M): Promise<AgentResponseData> {
+		if (isJsonObject(metadata)) {
+			return fromDataType(data, 'image/jpeg', metadata);
+		}
+		throw new Error('metadata must be a JsonObject');
 	}
 
 	/**
 	 * return a GIF response with optional metadata
 	 */
-	gif(data: DataType, metadata?: JsonObject): Promise<AgentResponseData> {
-		return fromDataType(data, 'image/gif', metadata);
+	gif<M = unknown>(data: DataType, metadata?: M): Promise<AgentResponseData> {
+		if (isJsonObject(metadata)) {
+			return fromDataType(data, 'image/gif', metadata);
+		}
+		throw new Error('metadata must be a JsonObject');
 	}
 
 	/**
 	 * return a WebP response with optional metadata
 	 */
-	webp(data: DataType, metadata?: JsonObject): Promise<AgentResponseData> {
-		return fromDataType(data, 'image/webp', metadata);
+	webp<M = unknown>(data: DataType, metadata?: M): Promise<AgentResponseData> {
+		if (isJsonObject(metadata)) {
+			return fromDataType(data, 'image/webp', metadata);
+		}
+		throw new Error('metadata must be a JsonObject');
 	}
 
 	/**
 	 * return a MP3 response with optional metadata
 	 */
-	mp3(data: DataType, metadata?: JsonObject): Promise<AgentResponseData> {
-		return fromDataType(data, 'audio/mpeg', metadata);
+	mp3<M = unknown>(data: DataType, metadata?: M): Promise<AgentResponseData> {
+		if (isJsonObject(metadata)) {
+			return fromDataType(data, 'audio/mpeg', metadata);
+		}
+		throw new Error('metadata must be a JsonObject');
 	}
 
 	/**
 	 * return a MP4 response with optional metadata
 	 */
-	mp4(data: DataType, metadata?: JsonObject): Promise<AgentResponseData> {
-		return fromDataType(data, 'audio/mp4', metadata);
+	mp4<M = unknown>(data: DataType, metadata?: M): Promise<AgentResponseData> {
+		if (isJsonObject(metadata)) {
+			return fromDataType(data, 'audio/mp4', metadata);
+		}
+		throw new Error('metadata must be a JsonObject');
 	}
 
 	/**
 	 * return a M4A response with optional metadata
 	 */
-	m4a(data: DataType, metadata?: JsonObject): Promise<AgentResponseData> {
-		return fromDataType(data, 'audio/m4a', metadata);
+	m4a<M = unknown>(data: DataType, metadata?: M): Promise<AgentResponseData> {
+		if (isJsonObject(metadata)) {
+			return fromDataType(data, 'audio/m4a', metadata);
+		}
+		throw new Error('metadata must be a JsonObject');
 	}
 
 	/**
 	 * return a M4P response with optional metadata
 	 */
-	m4p(data: DataType, metadata?: JsonObject): Promise<AgentResponseData> {
-		return fromDataType(data, 'audio/m4p', metadata);
+	m4p<M = unknown>(data: DataType, metadata?: M): Promise<AgentResponseData> {
+		if (isJsonObject(metadata)) {
+			return fromDataType(data, 'audio/m4p', metadata);
+		}
+		throw new Error('metadata must be a JsonObject');
 	}
 
 	/**
 	 * return a WebM response with optional metadata
 	 */
-	webm(data: DataType, metadata?: JsonObject): Promise<AgentResponseData> {
-		return fromDataType(data, 'audio/webm', metadata);
+	webm<M = unknown>(data: DataType, metadata?: M): Promise<AgentResponseData> {
+		if (isJsonObject(metadata)) {
+			return fromDataType(data, 'audio/webm', metadata);
+		}
+		throw new Error('metadata must be a JsonObject');
 	}
 
 	/**
 	 * return a HTML response with optional metadata
 	 */
-	async html(data: string, metadata?: JsonObject): Promise<AgentResponseData> {
-		return {
-			data: new DataHandler(data, 'text/html'),
-			metadata,
-		};
+	async html<M = unknown>(
+		data: string,
+		metadata?: M
+	): Promise<AgentResponseData> {
+		if (isJsonObject(metadata)) {
+			return {
+				data: new DataHandler(data, 'text/html'),
+				metadata,
+			};
+		}
+		throw new Error('metadata must be a JsonObject');
 	}
 
 	/**
 	 * return a WAV response with optional metadata
 	 */
-	wav(data: DataType, metadata?: JsonObject): Promise<AgentResponseData> {
-		return fromDataType(data, 'audio/wav', metadata);
+	wav<M = unknown>(data: DataType, metadata?: M): Promise<AgentResponseData> {
+		if (isJsonObject(metadata)) {
+			return fromDataType(data, 'audio/wav', metadata);
+		}
+		throw new Error('metadata must be a JsonObject');
 	}
 
 	/**
 	 * return an OGG response with optional metadata
 	 */
-	ogg(data: DataType, metadata?: JsonObject): Promise<AgentResponseData> {
-		return fromDataType(data, 'audio/ogg', metadata);
+	ogg<M = unknown>(data: DataType, metadata?: M): Promise<AgentResponseData> {
+		if (isJsonObject(metadata)) {
+			return fromDataType(data, 'audio/ogg', metadata);
+		}
+		throw new Error('metadata must be a JsonObject');
 	}
 
 	/**
 	 * stream a response to the client
 	 */
-	async stream(
+	async stream<M = unknown>(
 		stream: ReadableStream<ReadableDataType> | AsyncIterable<ReadableDataType>,
 		contentType?: string,
-		metadata?: JsonObject
+		metadata?: M
 	): Promise<AgentResponseData> {
-		return {
-			data: new DataHandler(stream, contentType ?? 'application/octet-stream'),
-			metadata,
-		};
+		if (isJsonObject(metadata)) {
+			return {
+				data: new DataHandler(
+					stream,
+					contentType ?? 'application/octet-stream'
+				),
+				metadata,
+			};
+		}
+		throw new Error('metadata must be a JsonObject');
 	}
 
 	/**
 	 * return a response with specific data and content type with optional metadata
 	 */
-	data(
+	data<M = unknown>(
 		data: DataType,
 		contentType: string,
-		metadata?: JsonObject
+		metadata?: M
 	): Promise<AgentResponseData> {
-		return fromDataType(data, contentType, metadata);
+		if (isJsonObject(metadata)) {
+			return fromDataType(data, contentType, metadata);
+		}
+		throw new Error('metadata must be a JsonObject');
 	}
 
 	/**
 	 * return a markdown response with optional metadata
 	 */
-	async markdown(
+	async markdown<M = unknown>(
 		content: string,
-		metadata?: JsonObject
+		metadata?: M
 	): Promise<AgentResponseData> {
-		return {
-			data: new DataHandler(content, 'text/markdown'),
-			metadata,
-		};
+		if (isJsonObject(metadata)) {
+			return {
+				data: new DataHandler(content, 'text/markdown'),
+				metadata,
+			};
+		}
+		throw new Error('metadata must be a JsonObject');
 	}
 }

--- a/src/server/agents.ts
+++ b/src/server/agents.ts
@@ -4,9 +4,8 @@ import type {
 	InvocationArguments,
 	RemoteAgentResponse,
 	ReadableDataType,
-	JsonObject,
-	ToJson,
 } from '../types';
+import { isJsonObject } from '../types';
 import type { ReadableStream } from 'node:stream/web';
 import { POST } from '../apis/api';
 import type { Logger } from '../logger';
@@ -56,9 +55,12 @@ class LocalAgentInvoker implements RemoteAgent {
 		this.description = description;
 	}
 
-	async run<T extends JsonObject>(
-		args?: InvocationArguments<ToJson<T>>
+	async run<T = unknown>(
+		args?: InvocationArguments<T>
 	): Promise<RemoteAgentResponse> {
+		if (!isJsonObject(args?.metadata)) {
+			throw new Error('args.metadata must be a JsonObject');
+		}
 		const tracer = getTracer();
 		const currentContext = context.active();
 
@@ -165,9 +167,12 @@ class RemoteAgentInvoker implements RemoteAgent {
 		this.transactionId = transactionId;
 	}
 
-	async run<T extends JsonObject>(
-		args?: InvocationArguments<ToJson<T>>
+	async run<T = unknown>(
+		args?: InvocationArguments<T>
 	): Promise<RemoteAgentResponse> {
+		if (!isJsonObject(args?.metadata)) {
+			throw new Error('args.metadata must be a JsonObject');
+		}
 		const tracer = getTracer();
 		const currentContext = context.active();
 

--- a/src/server/agents.ts
+++ b/src/server/agents.ts
@@ -4,6 +4,8 @@ import type {
 	InvocationArguments,
 	RemoteAgentResponse,
 	ReadableDataType,
+	JsonObject,
+	ToJson,
 } from '../types';
 import type { ReadableStream } from 'node:stream/web';
 import { POST } from '../apis/api';
@@ -54,7 +56,9 @@ class LocalAgentInvoker implements RemoteAgent {
 		this.description = description;
 	}
 
-	async run(args?: InvocationArguments): Promise<RemoteAgentResponse> {
+	async run<T extends JsonObject>(
+		args?: InvocationArguments<ToJson<T>>
+	): Promise<RemoteAgentResponse> {
 		const tracer = getTracer();
 		const currentContext = context.active();
 
@@ -161,7 +165,9 @@ class RemoteAgentInvoker implements RemoteAgent {
 		this.transactionId = transactionId;
 	}
 
-	async run(args?: InvocationArguments): Promise<RemoteAgentResponse> {
+	async run<T extends JsonObject>(
+		args?: InvocationArguments<ToJson<T>>
+	): Promise<RemoteAgentResponse> {
 		const tracer = getTracer();
 		const currentContext = context.active();
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,9 +151,14 @@ export type JsonKey = string | number | symbol;
 /**
  * JSON object type
  */
-export type JsonObject = {
-	[key in JsonKey]: JsonPrimitive;
-};
+-export type JsonKey = string | number | symbol;
++export type JsonKey = string | number;
+
+ export type JsonPrimitive = string | number | boolean | null;
+
+ export type JsonObject = {
+     [key in JsonKey]: JsonPrimitive;
+ };
 
 /**
  * Composite JSON type (array or object)

--- a/src/types.ts
+++ b/src/types.ts
@@ -145,7 +145,7 @@ export type JsonPrimitive =
  */
 export interface JsonArray extends Array<JsonPrimitive> {}
 
-export type JsonKey = string | number | symbol;
+export type JsonKey = string | number;
 
 /**
  * JSON object type

--- a/src/types.ts
+++ b/src/types.ts
@@ -148,14 +148,6 @@ export interface JsonArray extends Array<JsonPrimitive> {}
 
 export type JsonKey = string | number | symbol;
 
-export type ToJson<T> = T extends JsonPrimitive
-	? T
-	: T extends Array<infer U>
-		? ToJson<U>[]
-		: T extends object
-			? { [K in keyof T]-?: ToJson<T[K]> }
-			: never;
-
 /**
  * JSON object type
  */

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,9 @@ export interface Data {
 	stream(): Promise<ReadableStream<ReadableDataType>>;
 }
 
+/**
+ * check if a value is a Data object
+ */
 export function isDataObject(value: unknown): value is Data {
 	if (value && typeof value === 'object' && 'contentType' in value) {
 		return true;
@@ -96,13 +99,19 @@ export type DataType =
 	| ReadableStream
 	| Data;
 
-export function isReadableStream(value: unknown): value is ReadableStream {
+/**
+ * check if a value is a ReadableStream
+ */
+function isReadableStream(value: unknown): value is ReadableStream {
 	if (typeof value === 'object' && value !== null) {
 		return 'getReader' in value;
 	}
 	return false;
 }
 
+/**
+ * check if a value is a valid DataType
+ */
 export function isDataType(value: unknown): value is DataType {
 	if (value === null || value === undefined) {
 		return false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -145,19 +145,17 @@ export type JsonPrimitive =
  */
 export interface JsonArray extends Array<JsonPrimitive> {}
 
+/**
+ * valid keys for a JSON object
+ */
 export type JsonKey = string | number;
 
 /**
  * JSON object type
  */
--export type JsonKey = string | number | symbol;
-+export type JsonKey = string | number;
-
- export type JsonPrimitive = string | number | boolean | null;
-
- export type JsonObject = {
-     [key in JsonKey]: JsonPrimitive;
- };
+export type JsonObject = {
+	[key in JsonKey]: JsonPrimitive;
+};
 
 /**
  * Composite JSON type (array or object)
@@ -180,7 +178,6 @@ export function isJsonObject(value: unknown): value is JsonObject {
 	}
 	// if primitive types, they are ok
 	if (
-		typeof value === 'symbol' ||
 		typeof value === 'string' ||
 		typeof value === 'number' ||
 		typeof value === 'boolean'

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,7 +137,6 @@ export type JsonPrimitive =
 	| number
 	| boolean
 	| null
-	| undefined
 	| JsonArray
 	| JsonObject;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -438,7 +438,7 @@ export interface RemoteAgent {
 	 * @param args - the arguments to pass to the agent
 	 * @returns the response from the agent
 	 */
-	run(args: InvocationArguments<JsonObject>): Promise<RemoteAgentResponse>;
+	run<T = unknown>(args: InvocationArguments<T>): Promise<RemoteAgentResponse>;
 }
 
 interface GetAgentRequestParamsById {


### PR DESCRIPTION
A typesafe metadata JsonObject that is more flexible for practical use cases like this:

This should serialize fine to JSON:

```typescript
interface FooBar {
  bar: string;
  hello?: string;
}

const Bar: FooBar = {
  bar: "s",
};
```

I should then be able to use them in KV without type issues:

```typescript
const kvres = await ctx.kv.set("test", "foobar", Bar);
```

or vector search as metadata:

```typescript
const vectorres = await ctx.vector.search("test", {
  query: "foobar",
  limit: 1,
  metadata: {
    foo: Bar,
  },
});
```

or in handoff:

```typescript
return resp.handoff({name: "my agent" }, {
  metadata: {
    foo: Bar,
  },
});
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced runtime validation for metadata and data, ensuring only valid JSON objects are accepted in key methods and responses.
  - Improved flexibility for metadata and data types, allowing any valid JSON object as metadata across various APIs and responses.

- **Bug Fixes**
  - Added stricter checks to prevent invalid metadata from being processed, reducing potential errors.

- **Chores**
  - Updated documentation and version number to reflect the latest changes and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->