### PR TITLE
[AGENT-36] - logger message arg accepts number type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @agentuity/sdk Changelog
 
+## 0.0.118
+
+### Patch Changes
+
+- Logger enhancements
+
 ## 0.0.117
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentuity/sdk",
-	"version": "0.0.117",
+	"version": "0.0.118",
 	"description": "The Agentuity SDK for NodeJS and Bun",
 	"license": "Apache-2.0",
 	"public": true,

--- a/src/logger/console.ts
+++ b/src/logger/console.ts
@@ -33,7 +33,7 @@ export default class ConsoleLogger implements Logger {
 	 * @returns The formatted message with context
 	 * @private
 	 */
-	private formatMessage(message: string, args: unknown[]): string {
+	private formatMessage(message: string | number, args: unknown[]): string {
 		// Format the context string
 		const contextStr =
 			this.context && Object.keys(this.context).length > 0
@@ -64,7 +64,7 @@ export default class ConsoleLogger implements Logger {
 					...args
 				);
 			} else {
-				formattedMessage = _message;
+				formattedMessage = String(_message);
 			}
 		} catch (err) {
 			// If formatting fails, use a simple concatenation
@@ -89,7 +89,7 @@ export default class ConsoleLogger implements Logger {
 	 * @param message - The message to log
 	 * @param args - Additional arguments to log
 	 */
-	debug(message: string, ...args: unknown[]): void {
+	debug(message: string | number, ...args: unknown[]): void {
 		try {
 			const formattedMessage = this.formatMessage(message, args);
 			__originalConsole.debug(`${black}[DEBUG]${reset} ${formattedMessage}`);
@@ -106,7 +106,7 @@ export default class ConsoleLogger implements Logger {
 	 * @param message - The message to log
 	 * @param args - Additional arguments to log
 	 */
-	info(message: string, ...args: unknown[]): void {
+	info(message: string | number, ...args: unknown[]): void {
 		try {
 			const formattedMessage = this.formatMessage(message, args);
 			__originalConsole.info(`${green}[INFO]${reset}  ${formattedMessage}`);
@@ -123,7 +123,7 @@ export default class ConsoleLogger implements Logger {
 	 * @param message - The message to log
 	 * @param args - Additional arguments to log
 	 */
-	warn(message: string, ...args: unknown[]): void {
+	warn(message: string | number, ...args: unknown[]): void {
 		try {
 			const formattedMessage = this.formatMessage(message, args);
 			__originalConsole.warn(`${yellow}[WARN]${reset}  ${formattedMessage}`);
@@ -140,7 +140,7 @@ export default class ConsoleLogger implements Logger {
 	 * @param message - The message to log
 	 * @param args - Additional arguments to log
 	 */
-	error(message: string, ...args: unknown[]): void {
+	error(message: string | number, ...args: unknown[]): void {
 		try {
 			const formattedMessage = this.formatMessage(message, args);
 			__originalConsole.error(`${red}[ERROR]${reset} ${formattedMessage}`);

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -8,7 +8,7 @@ export interface Logger {
 	 * @param message - The message to log
 	 * @param args - Additional arguments to log
 	 */
-	debug(message: string | number, ...args: unknown[]): void;
+	debug(message: unknown, ...args: unknown[]): void;
 
 	/**
 	 * Log an info message
@@ -16,7 +16,7 @@ export interface Logger {
 	 * @param message - The message to log
 	 * @param args - Additional arguments to log
 	 */
-	info(message: string | number, ...args: unknown[]): void;
+	info(message: unknown, ...args: unknown[]): void;
 
 	/**
 	 * Log a warning message
@@ -24,7 +24,7 @@ export interface Logger {
 	 * @param message - The message to log
 	 * @param args - Additional arguments to log
 	 */
-	warn(message: string | number, ...args: unknown[]): void;
+	warn(message: unknown, ...args: unknown[]): void;
 
 	/**
 	 * Log an error message
@@ -32,7 +32,7 @@ export interface Logger {
 	 * @param message - The message to log
 	 * @param args - Additional arguments to log
 	 */
-	error(message: string | number, ...args: unknown[]): void;
+	error(message: unknown, ...args: unknown[]): void;
 
 	/**
 	 * Create a child logger with additional context

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -8,7 +8,7 @@ export interface Logger {
 	 * @param message - The message to log
 	 * @param args - Additional arguments to log
 	 */
-	debug(message: string, ...args: unknown[]): void;
+	debug(message: string | number, ...args: unknown[]): void;
 
 	/**
 	 * Log an info message
@@ -16,7 +16,7 @@ export interface Logger {
 	 * @param message - The message to log
 	 * @param args - Additional arguments to log
 	 */
-	info(message: string, ...args: unknown[]): void;
+	info(message: string | number, ...args: unknown[]): void;
 
 	/**
 	 * Log a warning message
@@ -24,7 +24,7 @@ export interface Logger {
 	 * @param message - The message to log
 	 * @param args - Additional arguments to log
 	 */
-	warn(message: string, ...args: unknown[]): void;
+	warn(message: string | number, ...args: unknown[]): void;
 
 	/**
 	 * Log an error message
@@ -32,7 +32,7 @@ export interface Logger {
 	 * @param message - The message to log
 	 * @param args - Additional arguments to log
 	 */
-	error(message: string, ...args: unknown[]): void;
+	error(message: string | number, ...args: unknown[]): void;
 
 	/**
 	 * Create a child logger with additional context

--- a/src/otel/console.ts
+++ b/src/otel/console.ts
@@ -32,19 +32,19 @@ export class ConsoleLogRecordExporter implements LogRecordExporter {
 		for (const log of logs) {
 			switch (log.severityNumber) {
 				case SeverityNumber.DEBUG:
-					this.logger.debug(log.body as string);
+					this.logger.debug(log.body);
 					break;
 				case SeverityNumber.INFO:
-					this.logger.info(log.body as string);
+					this.logger.info(log.body);
 					break;
 				case SeverityNumber.WARN:
-					this.logger.warn(log.body as string);
+					this.logger.warn(log.body);
 					break;
 				case SeverityNumber.ERROR:
-					this.logger.error(log.body as string);
+					this.logger.error(log.body);
 					break;
 				default:
-					this.logger.info(log.body as string);
+					this.logger.info(log.body);
 					break;
 			}
 		}

--- a/test/logger/console.test.ts
+++ b/test/logger/console.test.ts
@@ -160,6 +160,58 @@ describe('ConsoleLogger', () => {
 			const message = mockConsole.info.mock.calls[0][0];
 			expect(message).toContain('123');
 		});
+
+		it('should handle boolean as first argument', () => {
+			const logger = new ConsoleLogger();
+			
+			logger.info(true);
+			
+			expect(mockConsole.info).toHaveBeenCalled();
+			const message = mockConsole.info.mock.calls[0][0];
+			expect(message).toContain('true');
+		});
+
+		it('should handle null as first argument', () => {
+			const logger = new ConsoleLogger();
+			
+			logger.info(null);
+			
+			expect(mockConsole.info).toHaveBeenCalled();
+			const message = mockConsole.info.mock.calls[0][0];
+			expect(message).toContain('null');
+		});
+
+		it('should handle undefined as first argument', () => {
+			const logger = new ConsoleLogger();
+			
+			logger.info(undefined);
+			
+			expect(mockConsole.info).toHaveBeenCalled();
+			const message = mockConsole.info.mock.calls[0][0];
+			expect(message).toContain('undefined');
+		});
+
+		it('should handle object as first argument', () => {
+			const logger = new ConsoleLogger();
+			const obj = { name: 'test', value: 42 };
+			
+			logger.info(obj);
+			
+			expect(mockConsole.info).toHaveBeenCalled();
+			const message = mockConsole.info.mock.calls[0][0];
+			expect(message).toContain("{ name: 'test', value: 42 }");
+		});
+
+		it('should handle array as first argument', () => {
+			const logger = new ConsoleLogger();
+			const arr = [1, 'two', { three: 3 }];
+			
+			logger.info(arr);
+			
+			expect(mockConsole.info).toHaveBeenCalled();
+			const message = mockConsole.info.mock.calls[0][0];
+			expect(message).toContain("[ 1, 'two', { three: 3 } ]");
+		});
 	});
 
 	describe('child method', () => {

--- a/test/logger/console.test.ts
+++ b/test/logger/console.test.ts
@@ -150,6 +150,16 @@ describe('ConsoleLogger', () => {
 			expect(mockConsole.info).toHaveBeenCalled();
 			expect(mockConsole.error).toHaveBeenCalled();
 		});
+
+		it('should handle number as first argument', () => {
+			const logger = new ConsoleLogger();
+			
+			logger.info(123);
+			
+			expect(mockConsole.info).toHaveBeenCalled();
+			const message = mockConsole.info.mock.calls[0][0];
+			expect(message).toContain('123');
+		});
 	});
 
 	describe('child method', () => {


### PR DESCRIPTION
# Allow numbers as log message parameters

## Description
This PR enhances the Logger interface to accept numbers as the first parameter in all logging methods (debug, info, warn, error). Previously you'd get a TS error if you attempted to log a number.

## Changes
- Updated the Logger interface to allow `string | number` as the message parameter type
- Modified the ConsoleLogger implementation to handle number parameters
- Added explicit string conversion for consistent formatting
- Added a test case verifying that numeric parameters work correctly




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Logging methods now accept and properly format messages of any type, including objects, arrays, numbers, booleans, null, and undefined.
- **Bug Fixes**
	- Improved message formatting for non-string values in logs, ensuring clearer and more consistent output.
- **Tests**
	- Added tests to verify correct logging behavior for various message types.
- **Documentation**
	- Updated changelog to reflect logger enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->