### PR TITLE
Prevent multiple logs for the same exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @agentuity/sdk Changelog
 
+## 0.0.119
+
+### Patch Changes
+
+- Prevent multiple logs for the same error
+
 ## 0.0.118
 
 ### Patch Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@agentuity/sdk",
-	"version": "0.0.118",
+	"version": "0.0.119",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@agentuity/sdk",
-			"version": "0.0.118",
+			"version": "0.0.119",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/api": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentuity/sdk",
-	"version": "0.0.118",
+	"version": "0.0.119",
 	"description": "The Agentuity SDK for NodeJS and Bun",
 	"license": "Apache-2.0",
 	"public": true,

--- a/src/otel/index.ts
+++ b/src/otel/index.ts
@@ -241,11 +241,16 @@ export function registerOtel(config: OtelConfig): OtelResponse {
 				);
 			await otlpLogExporter
 				?.shutdown()
-				.catch((e) => logger.warn('error in shutdown of otel exporter. %s', e));
+				.catch(
+					(e) =>
+						!devmode && logger.warn('error in shutdown of otel exporter. %s', e)
+				);
 			await instrumentationSDK
 				?.shutdown()
-				.catch((e) =>
-					logger.warn('error in shutdown of otel instrumentation. %s', e)
+				.catch(
+					(e) =>
+						!devmode &&
+						logger.warn('error in shutdown of otel instrumentation. %s', e)
 				);
 			logger.debug('shut down OpenTelemetry');
 		}

--- a/src/server/agents.ts
+++ b/src/server/agents.ts
@@ -113,7 +113,7 @@ class LocalAgentInvoker implements RemoteAgent {
 				}
 				throw new Error(await resp.text());
 			} catch (ex) {
-				recordException(span, ex);
+				recordException(span, ex, true);
 				throw ex;
 			} finally {
 				span.end();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue to prevent multiple logs from being generated for the same error.
  - Suppressed warning logs during shutdown errors in development mode to reduce noise.
- **Chores**
  - Updated documentation to reflect the latest changes.
  - Incremented the version number to 0.0.119.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->