### PR TITLE
Expose thread id to the agent sdk 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @agentuity/sdk Changelog
 
+## 0.0.137
+
+### Patch Changes
+
+- Expose ts and ts_thread in the payload for Slack IO integration ([#157](https://github.com/agentuity/sdk-js/pull/157))
+
 ## 0.0.136
 
 ### Patch Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@agentuity/sdk",
-	"version": "0.0.136",
+	"version": "0.0.137",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@agentuity/sdk",
-			"version": "0.0.136",
+			"version": "0.0.137",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/api": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentuity/sdk",
-	"version": "0.0.136",
+	"version": "0.0.137",
 	"description": "The Agentuity SDK for NodeJS and Bun",
 	"license": "Apache-2.0",
 	"public": true,
@@ -8,7 +8,10 @@
 	"main": "dist/index.js",
 	"module": "dist/index.js",
 	"type": "module",
-	"files": ["dist/**/*", "LICENSE.md"],
+	"files": [
+		"dist/**/*",
+		"LICENSE.md"
+	],
 	"engines": {
 		"node": ">=22"
 	},
@@ -21,9 +24,17 @@
 	"bugs": {
 		"url": "https://github.com/agenuity/sdk-js/issues"
 	},
-	"keywords": ["ai", "agents", "agentuity", "ai agent", "agent"],
+	"keywords": [
+		"ai",
+		"agents",
+		"agentuity",
+		"ai agent",
+		"agent"
+	],
 	"tsup": {
-		"entry": ["src/index.ts"],
+		"entry": [
+			"src/index.ts"
+		],
 		"format": "esm",
 		"splitting": false,
 		"sourcemap": true,

--- a/src/io/slack.ts
+++ b/src/io/slack.ts
@@ -1,9 +1,9 @@
 import { inspect } from 'node:util';
-import type { AgentRequest, AgentContext, SlackService } from '../types';
-import { getTracer, recordException } from '../router/router';
-import { context, trace, SpanStatusCode } from '@opentelemetry/api';
+import { SpanStatusCode, context, trace } from '@opentelemetry/api';
 import { POST } from '../apis/api';
+import { getTracer, recordException } from '../router/router';
 import { safeStringify } from '../server/util';
+import type { AgentContext, AgentRequest, SlackService } from '../types';
 
 // Event represents the inner event data for Slack events
 interface SlackEventData {
@@ -14,6 +14,7 @@ interface SlackEventData {
 	ts: string;
 	event_ts: string;
 	channel_type: string;
+	thread_ts?: string;
 }
 
 // SlackEvent represents a Slack event webhook payload
@@ -39,6 +40,9 @@ interface SlackMessagePayload {
 	text: string;
 	response_url: string;
 	trigger_id: string;
+	ts: string;
+	thread_ts?: string;
+	event_ts?: string;
 }
 
 /**
@@ -154,6 +158,22 @@ export class Slack implements SlackService {
 
 	get triggerId(): string | undefined {
 		return this.messagePayload?.trigger_id;
+	}
+
+	get threadTs(): string | undefined {
+		return this.eventPayload?.event?.thread_ts;
+	}
+
+	get eventTs(): string | undefined {
+		return this.eventPayload?.event?.event_ts;
+	}
+
+	get ts(): string | undefined {
+		return this.eventPayload?.event?.ts;
+	}
+
+	get body(): string | undefined {
+		return JSON.stringify(this.eventPayload);
 	}
 
 	// Common text getter that works for both types


### PR DESCRIPTION
<img width="343" height="226" alt="image" src="https://github.com/user-attachments/assets/59fe1037-e43f-49b2-afd4-b965438f8da4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for accessing thread and event timestamps in Slack messages and events.
  * Provided a way to view the serialized event payload for Slack events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->