### PR TITLE
Increase api timeout from 20 seconds to NEVER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @agentuity/sdk Changelog
 
+## 0.0.142
+
+### Patch Changes
+
+- Some APIs like object store were timing out after 20s with a large document upload. Remove the premature timeout
+
 ## 0.0.141
 
 ### Patch Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@agentuity/sdk",
-	"version": "0.0.140",
+	"version": "0.0.142",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@agentuity/sdk",
-			"version": "0.0.140",
+			"version": "0.0.142",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/api": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentuity/sdk",
-	"version": "0.0.141",
+	"version": "0.0.142",
 	"description": "The Agentuity SDK for NodeJS and Bun",
 	"license": "Apache-2.0",
 	"public": true,

--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -116,7 +116,7 @@ export async function send<K>(
 		body: request.body,
 		headers,
 		keepalive: true,
-		signal: AbortSignal.timeout(request.timeout || 20_000),
+		signal: request.timeout ? AbortSignal.timeout(request.timeout) : undefined,
 	});
 	let json: K | null = null;
 	switch (resp.status) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the implicit 20-second timeout on network requests. Requests now only time out when a timeout is explicitly provided, avoiding unintended cancellations for long-running uploads or operations.
  * Existing behavior unchanged for calls that already specify a timeout.

* **Chores**
  * Release metadata updated (version bump) and changelog entry added. No public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->