### PR TITLE
Stream improvements

### DIFF
--- a/.changeset/silly-shoes-nail.md
+++ b/.changeset/silly-shoes-nail.md
@@ -1,0 +1,7 @@
+---
+"@agentuity/sdk": patch
+---
+
+Adds the ability to getReader() to return a reader for the Stream
+Immediately schedules tasks sent to context.waitUntil instead of waiting until the response is returned
+Adds the ability to return a Stream directly from a Agent handler and have it return a 302 with the stream location automatically

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -23,6 +23,7 @@ import type {
 	GetAgentRequestParams,
 	ReadableDataType,
 	RemoteAgent,
+	Stream,
 } from '../types';
 import AgentRequestHandler from './request';
 import AgentResponseHandler from './response';
@@ -349,7 +350,22 @@ export function createRouter(config: RouterConfig): ServerRoute['handler'] {
 										'handler returned null instead of a response'
 									);
 								}
-
+								// check to see if this is a Stream
+								if (
+									typeof handlerResponse === 'object' &&
+									'url' in handlerResponse &&
+									'id' in handlerResponse &&
+									'close' in handlerResponse
+								) {
+									const streamResponse = handlerResponse as unknown as Stream;
+									const url = streamResponse.url;
+									return new Response(null, {
+										status: 302,
+										headers: {
+											Location: url,
+										},
+									});
+								}
 								if (handlerResponse instanceof Response) {
 									return await handlerResponse;
 								}

--- a/src/types.ts
+++ b/src/types.ts
@@ -385,7 +385,7 @@ export interface StreamAPI {
 	/**
 	 * create a new stream
 	 *
-	 * @param name - the name of the stream (1-254 characters)
+	 * @param name - the name of the stream (1-254 characters). you can group streams by name to organize them.
 	 * @param props - optional properties for creating the stream
 	 * @returns a Promise that resolves to the created Stream
 	 */

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -785,9 +785,11 @@ describe('StreamAPI', () => {
 
 	describe('getReader', () => {
 		let fetchCalls: Array<[URL | RequestInfo, RequestInit | undefined]>;
+		let originalFetch: typeof fetch;
 
 		beforeEach(() => {
 			fetchCalls = [];
+			originalFetch = globalThis.fetch;
 
 			const mockFetch = mock(async (url: URL | RequestInfo, options?: RequestInit) => {
 				fetchCalls.push([url, options]);
@@ -836,6 +838,10 @@ describe('StreamAPI', () => {
 
 			setFetch(mockFetch as unknown as typeof fetch);
 			globalThis.fetch = mockFetch as unknown as typeof fetch;
+		});
+
+		afterEach(() => {
+			globalThis.fetch = originalFetch;
 		});
 
 		it('should return a ReadableStream when calling getReader()', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added getReader() to read streaming responses directly.
  - Agent handlers can return a Stream; router now issues a 302 redirect to the stream URL.
  - Tasks passed to context.waitUntil start immediately for faster follow-up work.
- Documentation
  - Changelog entry added for the patch release.
- Tests
  - Comprehensive tests for getReader covering request headers, streaming data, multi-chunk reads, auth fallback, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->