### PR TITLE
Fixed issue where some outbound API requests dont have correct otel headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @agentuity/sdk Changelog
 
+## 0.0.152
+
+### Patch Changes
+
+- Fixed issue with otel headers not propagating for outbound services
+
 ## 0.0.151
 
 ### Patch Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@agentuity/sdk",
-	"version": "0.0.150",
+	"version": "0.0.152",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@agentuity/sdk",
-			"version": "0.0.150",
+			"version": "0.0.152",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/api": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentuity/sdk",
-	"version": "0.0.151",
+	"version": "0.0.152",
 	"description": "The Agentuity SDK for NodeJS and Bun",
 	"license": "Apache-2.0",
 	"public": true,

--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -1,3 +1,4 @@
+import { context, propagation } from '@opentelemetry/api';
 import { getSDKVersion } from '../router/router';
 import { isReadableStream } from '../types';
 
@@ -141,6 +142,15 @@ export async function send<K>(
 	for (const key in request.headers) {
 		headers[key] = request.headers[key];
 	}
+
+	// inject trace context headers if there's an active context
+	const currentContext = context.active();
+	propagation.inject(currentContext, headers, {
+		set: (carrier, key, value) => {
+			carrier[key] = value;
+		},
+	});
+
 	// this shouldn't be overridden
 	headers.Authorization = `Bearer ${apiKey}`;
 	const init: RequestInit & { duplex?: 'half' } = {

--- a/src/apis/prompt/generated/_index.js
+++ b/src/apis/prompt/generated/_index.js
@@ -1,5 +1,4 @@
-export const prompts = {
-};
+export const prompts = {};
 
 // Export types for compatibility
 export const PromptConfig = undefined; // Type-only export, value is not used

--- a/src/apis/vector.ts
+++ b/src/apis/vector.ts
@@ -137,7 +137,7 @@ export default class VectorAPI implements VectorStorage {
 				);
 				if (resp.status === 200) {
 					if (resp.json?.success) {
-						const json = resp.json as unknown as { data: { id: string; }[]; };
+						const json = resp.json as unknown as { data: { id: string }[] };
 						span.setStatus({ code: SpanStatusCode.OK });
 						return json.data.map((o) => o.id);
 					}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Version
  - Bumped package to 0.0.152.
- Bug Fixes
  - Fixed OpenTelemetry trace context propagation for outbound requests, ensuring trace headers are correctly injected and preserved alongside custom headers. Authorization header remains unaffected.
- Documentation
  - Updated changelog with 0.0.152 patch notes detailing the OTEL propagation fix.
- Tests
  - Added comprehensive tests for trace context behavior, including cases with/without active context and preservation of existing headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->